### PR TITLE
Minor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 json = "0.12.4"
+dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,12 @@
 name = "chatcmd"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+build = "build.rs"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 json = "0.12.4"
+dotenv_codegen = "0.15.0"
+
+[build-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ build = "build.rs"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 json = "0.12.4"
 dotenv_codegen = "0.15.0"
+atty = "0.2.14"
+serde_json = "1.0.68"
 
 [build-dependencies]
 dotenv = "0.15.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+use std::{env, path::Path};
+
+fn main() {
+    let dotenv_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join(".env");
+    
+    if dotenv_path.exists() {
+        // Emit a custom flag if .env exists
+        println!("cargo:rustc-cfg=dotenv_available");
+
+    }
+    println!("cargo:rerun-if-changed=.env");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Error> {
     let osspec = "You are an expert on linux bash and know the intrincate details of running programs in windows through it's command line versions. I'll ask you for help with some command of some program and you will return just one command line result without providing any explanation except that you are explicitily asked for it.Don't quote or escape the output.";
 
     let system = match dev_mode {
-        true => "You are an expert developer. The user is also an experienced developer and need to ask a very specific question and need a consise answer providing only code without comments or explanations. Name variables and funcitons appropietly.Don't quote or escape the output.",
+        true => "You are an expert developer. The user is also an experienced developer and need to ask a very specific question and need a consise answer providing only code without comments or explanations. Name variables and funcitons appropietly.Don't quote or escape the output. The output needs to be able to piped into a file. just print the code, no markdown block",
         false => osspec,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::process::{Command, Stdio};
 use reqwest::blocking::Client;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Error;
+use dotenv::dotenv;
 
 extern crate json;
 
@@ -86,6 +87,10 @@ fn main() -> Result<(), Error> {
 }
 
 fn ask_for_key() -> Option<String> {
+    if let Err(e) = dotenv() {
+        eprintln!("Failed to load .env file: {}", e);
+    }
+
     let env_var_name = "OPENAI_API_KEY";
     let api_key = env::var(env_var_name);
 


### PR DESCRIPTION
Hi! I added:
- Being able to load the API key from a .env file. (its loaded at compile time if the .env file is present) --not encrypted yet...
- `-dev` mode now can print code that can be piped
- chatcmd now can accept stdin to chain requests

This works now:
`chatcmd -dev make a simple hello world in python > test.out`

`cat test.out | chatcmd improve this by adding a date`
```
Reading from stdin
python -c "import datetime; print('Hello, World -', datetime.datetime.now().strftime('%Y-%m-%d'))"
```
This also:
`chatcmd improve this by adding a date < test.out`

This ...sometimes...
`diego@buntu:~/git/chatcmd$ chatcmd -dev make a simple hello world in python | chatcmd improve this by adding a date`
